### PR TITLE
refactor opening settings.yaml in tarbell configure, fixes #103

### DIFF
--- a/tarbell/configure.py
+++ b/tarbell/configure.py
@@ -67,14 +67,14 @@ def _get_or_create_config(path, prompt=True):
     except OSError:
         pass
 
-    #if os.path.isfile(path):
-        #puts("{0} already exists, backing up".format(colored.green(path)))
-        #_backup(dirname, filename)
-
-    with open(path, 'r+') as f:
-        settings = yaml.load(f)
-
-    return settings or {}
+    try:
+        with open(path, 'r+') as f:
+            if os.path.isfile(path):
+                puts("{0} already exists, backing up".format(colored.green(path)))
+                _backup(dirname, filename)
+            return yaml.load(f)
+    except IOError:
+        return {}
 
 
 def _setup_google_spreadsheets(settings, path, prompt=True):


### PR DESCRIPTION
Handle opening or creating file using try/except. There's still a bit of cruft: there's an if block checking on the file existence in a try/except block designed to catch a missing file. But if we don't check, the "backup" print statement will appear even when there's no file to backup and Tarbell bombs.
