### PR TITLE
Adding Google Analytics to newproject and tarbell_config.py

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -262,6 +262,11 @@ class TarbellSite:
             self.client = None
 
         try:
+            self.ga_id = project.GOOGLE_ANALYTICS_ID
+        except AttributeError:
+            self.ga_id = ''
+
+        try:
             project.CREATE_JSON
         except AttributeError:
             project.CREATE_JSON = False
@@ -330,6 +335,7 @@ class TarbellSite:
                 "ROOT_URL": "127.0.0.1:5000",
                 "PATH": path,
                 "SPREADSHEET_KEY": self.key,
+                "GOOGLE_ANALYTICS_ID": self.ga_id
             })
             if extra_context:
                 context.update(extra_context)

--- a/tarbell/cli.py
+++ b/tarbell/cli.py
@@ -360,8 +360,14 @@ def tarbell_newproject(command, args):
         # Create spreadsheet
         key = _create_spreadsheet(name, title, path, settings)
 
+        # Add Google Analytics ID
+        use = raw_input("\nWould you like to use Google Analytics [Y/n]? ")
+        ga_id = ""
+        if use.lower() == "y":
+            ga_id = raw_input("\nWhat is the Google Analytics ID to use for this project? [Typically formatted like UA-XXXXXXX-Y] ")
+
         # Create config file
-        _copy_config_template(name, title, template, path, key, settings)
+        _copy_config_template(name, title, template, path, key, ga_id, settings)
 
         # Copy html files
         puts(colored.green("\nCopying html files..."))
@@ -543,7 +549,7 @@ def _add_user_to_file(file_id, service, user_email,
         print 'An error occurred: %s' % error
 
 
-def _copy_config_template(name, title, template, path, key, settings):
+def _copy_config_template(name, title, template, path, key, ga_id, settings):
         """Get and render tarbell_config.py.template from base"""
         puts("\nCopying configuration file")
         context = settings.config
@@ -556,6 +562,7 @@ def _copy_config_template(name, title, template, path, key, settings):
             "title": title,
             "template_repo_url": template.get('url'),
             "key": key,
+            "ga_id": ga_id
         })
 
         # @TODO refactor this a bit

--- a/tarbell/templates/tarbell_config.py.template
+++ b/tarbell/templates/tarbell_config.py.template
@@ -19,6 +19,9 @@ EXCLUDES = ["*.md", "requirements.txt"]
 # Create JSON data at ./data.json, disabled by default
 # CREATE_JSON = True
 
+# Google Analytics ID to track this site
+{% if not ga_id %}#{% endif %}GOOGLE_ANALYTICS_ID = "{{ ga_id }}"
+
 # S3 bucket configuration
 {% if not default_s3_buckets %}#{% endif %}S3_BUCKETS = {
     # Provide target -> s3 url pairs, such as:


### PR DESCRIPTION
I've already updated the 0.9b5 branch of tarbell-template to use the new GOOGLE_ANALYTICS_ID that this system generates. The Trib template hardcodes a GA ID because we use the same one for all Tarbell projects, not sure if we should change that or not. It'd be nice if we could prompt users with the default and let them customize it if they want, but not sure if that's possible currently.
