### PR TITLE
Render json files too

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -37,6 +37,7 @@ TEMPLATE_TYPES = [
     "text/html",
     "text/css",
     "application/javascript",
+    "application/json",
 ]
 
 def split_template_path(template):


### PR DESCRIPTION
Hey Newsapps,

I know this isn't asked for but it helped me do cool stuff for a project. It makes tarbell also render json files. Example usage:

`_base/base.py`

```
...
from pymongo import MongoClient
...
def minus_k(d, k):
    d.pop(k)
    return d

blueprint = Blueprint('base', __name__)

client = MongoClient()
db = client['ant_farm']
soa_db = db['school_of_ants'']
data = [minus_k(row, '_id') for row in soa_db.find()]

@blueprint.app_context_processor
def inject_soadb():
    return {'db': data}
...

```

`data.json`

```
{{ db|tojson }}

```

`app.js`

```
$.getJSON('/data.json', function(d) {
    console.log(d);
});

```

This way I can have static json data and load it async with Javascript. 
