### PR TITLE
removing READLINE requirement. Fixes #236

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ settings.update(
         "google-api-python-client==1.2",
         "keyring==4.0",
         "python-dateutil>=2.2",
-        "gnureadline==6.3.3",
         "requests==2.3.0",
         "sh==1.09",
         "wsgiref==0.1.2",


### PR DESCRIPTION
since `pip install readline` often fails and default python ships with readline, this removes the readline requirement. 
