### PR TITLE
Give data.json an explicit route

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -452,7 +452,7 @@ class TarbellSite:
 
         return filepath, mimetype
 
-    def data_json(self):
+    def data_json(self, extra_context=None, publish=False):
         """
         Serve site context as JSON. Useful for debugging.
         """
@@ -461,7 +461,7 @@ class TarbellSite:
 
         if not self.data:
             # this sets site.data by spreadsheet or gdoc
-            self.get_context()
+            self.get_context(publish)
 
         return jsonify(self.data)
 
@@ -683,10 +683,17 @@ class TarbellSite:
 
         if not self.quiet:
             puts("Writing {0}".format(output_path))
+
         with self.app.test_request_context():
-            preview = self.preview(rel_path, extra_context=extra_context, publish=True)
+            # data.json is special
+            if filename == 'data.json':
+                preview = self.data_json(extra_context, publish=True)
+            else:
+                preview = self.preview(rel_path, extra_context=extra_context, publish=True)
+            
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
+
             with open(output_path, "wb") as f:
                 if isinstance(preview.response, FileWrapper):
                     f.write(preview.response.file.read())


### PR DESCRIPTION
This defines a route for the `data.json` endpoint, adds a function to handle it and updates static site generation to build it. Right now, this only serving `site.data`, not all context, which is a slight change in functionality. I did this because the `DEFAULT_CONTEXT` setting is where I usually add global template functions, and that will break JSON encoding.

Closes #270.
