### PR TITLE
Run preprocess_request when building static site

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -675,10 +675,17 @@ class TarbellSite:
 
         if not self.quiet:
             puts("Writing {0}".format(output_path))
+
         with self.app.test_request_context():
+            # call any pre-request hooks
+            self.app.preprocess_request()
+
+            # render
             preview = self.preview(rel_path, extra_context=extra_context, publish=True)
+            
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
+            
             with open(output_path, "wb") as f:
                 if isinstance(preview.response, FileWrapper):
                     f.write(preview.response.file.read())


### PR DESCRIPTION
This is a one-line change that fixes #286. It means I won't have to do this anymore:

```python
@blueprint.app_context_processor
def process_data():
    # tarbell generate might not be running preprocess_request
    if not g.get('current_site'):
        current_app.preprocess_request()
    # ... rest of the function
```

And I can just do this:

```python
@blueprint.app_context_processor
def process_data():
    context = g.current_site.get_context()
    # do things with site data ...
```
