### PR TITLE
catch encoding error writing output, handle by encoding string

### DIFF
--- a/tarbell/utils.py
+++ b/tarbell/utils.py
@@ -6,21 +6,25 @@ tarbell.utils
 
 This module provides utilities for Tarbell.
 """
-
+from __future__ import unicode_literals
 import os
 import sys
 from clint.textui import colored, puts as _puts
 
+STDOUT = sys.stdout.write
 
 def is_werkzeug_process():
     """Is the current process the werkzeug reloader thread? Return True if so."""
     return os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
 
 
-def puts(*args, **kwargs):
+def puts(s='', newline=True, stream=STDOUT):
     """Wrap puts to avoid getting called twice by Werkzeug reloader"""
     if not is_werkzeug_process():
-        return _puts(*args, **kwargs)
+        try:
+            return _puts(s, newline, stream)
+        except UnicodeEncodeError:
+            return _puts(s.encode(sys.stdout.encoding), newline, stream)
 
 
 def list_get(l, idx, default=None):


### PR DESCRIPTION
closes #285 by catching error on un-encoded stdout and encoding it according to current tty encoding