### PR TITLE
disable frozen's file deletion mechanisms to preserve backwards compatibility

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -271,6 +271,7 @@ class TarbellSite:
 
         # centralized freezer setup
         self.app.config.setdefault('FREEZER_RELATIVE_URLS', True)
+        self.app.config.setdefault('FREEZER_REMOVE_EXTRA_FILES', False)
         self.app.config.setdefault('FREEZER_DESTINATION', 
             os.path.join(os.path.realpath(self.path), '_site'))
 


### PR DESCRIPTION
flask frozen clears out the directory it's about to freeze in by default, but tarbell handles that already and some in-the-wild projects rely on manually writing to the filesystem. fortunately, it's easily disabled. refs #311