### PR TITLE
catch real error, not template error, if no custom error page exists

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -740,7 +740,6 @@ class TarbellSite:
         Find all file paths for publishing, yield (urlname, kwargs)
         """
         # yield blueprint paths first
-
         if getattr(self, 'blueprint_name', None):
             for path in walk_directory(os.path.join(self.path, self.blueprint_name), ignore=self.project.EXCLUDES):
                 yield 'preview', {'path': path}

--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -544,6 +544,7 @@ class TarbellSite:
                 return send_from_directory(dir, filename)
 
         except Exception as e:
+            ex_type, ex, tb = sys.exc_info()
             try:
                 # Find template with name of error
                 cls = e.__class__
@@ -569,7 +570,6 @@ class TarbellSite:
                 return Response(rendered, mimetype="text/html")
             except TemplateNotFound:
                 # Otherwise raise old error
-                ex_type, ex, tb = sys.exc_info()
                 raise ex_type, ex, tb
 
         # Last ditch effort -- see if path has "index.html" underneath it


### PR DESCRIPTION
closes #360 