### PR TITLE
Corrects docs in a couple places

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -355,7 +355,7 @@ Frozen-Flask will automatically track every call to `url_for` and build out thos
       rows = data.get('list_items', [])
 
       for row in rows:
-          yield ('myproject.social_stub', row['id'])
+          yield ('myproject.social_stub', {'id': row['id']})
 
   @register_hook('generate')
   def register_social_stubs(site, output_root, extra_context):

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,5 +2,5 @@
 Contributing
 ============
 
-* Github repository: https://github.com/newsapps/flask-tarbell
+* Github repository: https://github.com/tarbell-project/tarbell
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -51,10 +51,9 @@ Updates blueprint with git submodule update.
 
 *Requires current directory to be a Tarbell project.*
 
-**Usage:** ``tarbell generate <optional: output directory>``
+**Usage:** ``tarbell generate <output directory>``
 
-Make HTML on the file system. If output directory is not specified, a temporary directory will be
-used.
+Make HTML on the file system. If output directory is not specified, Tarbell will raise an error asking for one.
 
 ``tarbell switch``
 ------------------


### PR DESCRIPTION
Fixes #392 with the correct return value for a URL generator, which should be `('viewname', {'key': 'value'})`. That is, the second part of the tuple should be a dictionary with view args.

Fixes #394 to point to this repo, instead of the old newsapps organiztion.

Fixes #398 so docs reflect current behavior of `tarbell generate` (output directory is required). It's worth deciding if that's the desired behavior, but for now, docs should be correct.

