### PR TITLE
Document Tarbell's context variables and their usage

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -190,22 +190,25 @@ When you run `tarbell publish`, Tarbell again sets additional context variables,
 Where can context variables be used?
 ------------------------------------
 
-Context variables can be used in HTML, CSS, and Javascript files. If the text file causes a Jinja
-template error (which can happen if the file has Jinja-like markers), the file will be served as static
-and the preview server will log an error.
+Context variables only work in HTML files. If rendering the file causes a Jinja
+template error (which can happen if the file has Jinja-like markers), you'll see an error page with debugging information.
 
-This means that CSS and Javascript files may include variables. ``style.css`` might include:
+While CSS and Javascript files can't include variables, it is possible (and common) to use template variables inside `script` and `style` tags on HTML pages. For example:
 
-.. code-block:: css
+.. code-block:: html
 
+  <style type="text/css">
   #content { font-size: {{ font_size }}; }
+  </style>
 
-Similarly, a Javascript file could include:
+Similarly, a script tag could be included like so:
 
-.. code-block:: javascript
-
+.. code-block:: html
+  
+  <script type="text/javascript">
   var data = {{ photos|tojson|safe }}
   console.log(photos.intro.url);
+  </script>
 
 Use this feature with care! Missing variables could easily break your CSS or Javascript.
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -172,6 +172,21 @@ Access a list of data:
     {% endfor %}
   </ul>
 
+In addition to `DEFAULT_CONTEXT`, Tarbell sets the following variables:
+
+ - `PROJECT_PATH`: the filesystem path to the directory containing your `tarbell_config.py` file
+ - `ROOT_URL`: the hostname for your site, initially `127.0.0.1:5000` (this changes when publishing)
+ - `SPREADSHEET_KEY`: the `SPREADSHEET_KEY` variable in your `tarbell_config.py` (or `None` if not set)
+ - `BUCKETS`: the `S3_BUCKETS` variable in your `tarbell_config.py`
+ - `SITE`: the current Tarbell site object
+
+When you run `tarbell publish`, Tarbell again sets additional context variables, based on your S3 settings. For example, if your `production` bucket is named `apps.example.com` in a project named `my-story`, these variables would be added to your site context when you run `tarbell publish production` (or `tarbell publish`):
+
+ - `ROOT_URL`: the host and path you're publishing to (for example, `apps.example.com/my-story`)
+ - `S3_BUCKET`: the name of the bucket you're publishing to (`apps.example.com`)
+ - `BUCKET_NAME`: the name of the publishing target, `production` or `staging` (this is the first argument after `tarbell publish`)
+
+
 Where can context variables be used?
 ------------------------------------
 


### PR DESCRIPTION
Fixes #362 and #405 to better document available template variables and show where they can be used.