### PR TITLE
Support for custom template types

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -190,10 +190,10 @@ When you run `tarbell publish`, Tarbell again sets additional context variables,
 Where can context variables be used?
 ------------------------------------
 
-Context variables only work in HTML files. If rendering the file causes a Jinja
+By default, context variables only work in HTML files. If rendering the file causes a Jinja
 template error (which can happen if the file has Jinja-like markers), you'll see an error page with debugging information.
 
-While CSS and Javascript files can't include variables, it is possible (and common) to use template variables inside `script` and `style` tags on HTML pages. For example:
+It is possible (and common) to use template variables inside `script` and `style` tags on HTML pages. For example:
 
 .. code-block:: html
 
@@ -211,6 +211,23 @@ Similarly, a script tag could be included like so:
   </script>
 
 Use this feature with care! Missing variables could easily break your CSS or Javascript.
+
+Adding custom template types
+----------------------------
+
+By default, Tarbell will treat any file with a mimetype other than `text/html` as a static file as serve it as-is. This is by design, for both speed (all your Javascript files don't need to run through Jinja templating) and safety (it's easy to break your Javascript with a misplaced tag). But you may decide you need more than HTML rendered.
+
+In that case, add the `TEMPLATE_TYPES` variable to your `tarbell_config.py` file with a list of additional mimetypes to render. For example:
+
+
+.. code-block:: python
+
+  # tarbell_config.py
+
+  TEMPLATE_TYPES = ['text/plain', 'application/xml', 'text/css']
+
+This would add support for rendering plain text, XML and CSS files as templates. 
+
 
 Anatomy of a project directory
 ------------------------------

--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -40,9 +40,9 @@ SPREADSHEET_CACHE_TTL = 4
 VALID_CELL_TYPES = range(1, 5)
 
 # pass template variables to files with these mimetypes
-TEMPLATE_TYPES = [
+TEMPLATE_TYPES = (
     "text/html",
-]
+)
 
 EXCLUDES = ['.git/*', '.git', '.gitignore', '.*', '*.pyc', '*.py', '_*']
 
@@ -431,6 +431,9 @@ class TarbellSite:
             # Merge excludes
             project.EXCLUDES = EXCLUDES + base.EXCLUDES + list(set(project.EXCLUDES) - set(base.EXCLUDES))
 
+        # merge project template types with defaults
+        project.TEMPLATE_TYPES = set(getattr(project, 'TEMPLATE_TYPES', [])) | set(TEMPLATE_TYPES)
+
         try:
             project.DEFAULT_CONTEXT
         except AttributeError:
@@ -525,7 +528,7 @@ class TarbellSite:
             filepath, mimetype = self._resolve_path(path)
 
             # Serve dynamic
-            if filepath and mimetype and mimetype in TEMPLATE_TYPES:
+            if filepath and mimetype and mimetype in self.project.TEMPLATE_TYPES:
                 context = self.get_context(publish)
                 context.update({
                     "PATH": path,


### PR DESCRIPTION
Addresses #264 by allowing a user to set a `TEMPLATE_TYPES` variable in `tarbell_config.py`. For example:

```python
# tarbell_config.py

TEMPLATE_TYPES = ['text/plain', 'application/xml', 'text/css']
```

This would *add* support for rendering plain text, XML and CSS files as templates. There's no way to turn off support for HTML (and I don't think we'd want that anyway, right?) under this implementation.