### PR TITLE
Move template filters and functions into a dedicated module

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -11,6 +11,7 @@ If you create a file in your project directory called ``chapter1.html``, you'll 
 
 Files and directories that start with an underscore (``_``) or a dot (``.``), like the ``_blueprint`` directory containing the Tarbell blueprint files, will not be rendered by the preview server or included in the generated static HTML.
 
+
 Understanding Tarbell Blueprints
 --------------------------------
 
@@ -212,6 +213,8 @@ Similarly, a script tag could be included like so:
 
 Use this feature with care! Missing variables could easily break your CSS or Javascript.
 
+
+
 Adding custom template types
 ----------------------------
 
@@ -303,6 +306,20 @@ index.html
   This is a fallback version of the project's front page, in case the ``index.html`` file in the root
   directory is removed or renamed. It begins life as an exact copy of the root directory's 
   ``index.html``.
+
+
+
+Using and extending template filters and functions
+---------------------------------------------------
+
+Flask and Tarbell each extend the default set of Jinja2 template filters to handle common needs when building projects. All of the filters and configuration detaled in the `Flask documentation on templates <http://flask.pocoo.org/docs/0.10/templating/>`_ applies to Tarbell, too.
+
+Tarbell provides the following filters by default:
+
+.. automodule:: tarbell.template
+   :members: read_file, render_file, markdown, format_date, pprint_lines
+
+
 
 Adding custom routes
 --------------------

--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-import codecs
 import csv
 import datetime
-import dateutil
 import fnmatch
 import imp
-import markdown as md
 import mimetypes
 import os
 import re
@@ -18,20 +15,17 @@ import xlrd
 from httplib import BadStatusLine
 from flask import Flask, Blueprint, render_template, send_from_directory, Response, g, jsonify
 from flask_frozen import Freezer, walk_directory
-from jinja2 import contextfunction, Markup
 from jinja2.loaders import BaseLoader
 from jinja2.utils import open_if_exists
 from jinja2.exceptions import TemplateNotFound
 from jinja2._compat import string_types
-from pprint import pformat
-from slughifi import slughifi
 from string import uppercase
-from werkzeug.wsgi import FileWrapper
 from clint.textui import puts
 
 from .errors import MergedCellError
 from .oauth import get_drive_api
 from .hooks import hooks
+from .slughifi import slughifi
 from .template import filters, silent_none
 
 # in seconds

--- a/tarbell/cli.py
+++ b/tarbell/cli.py
@@ -38,7 +38,8 @@ MAJOR_VERSION = '.'.join(VERSION.split('.')[:2])
 if __name__ == "__main__" and __package__ is None:
     __package__ = "tarbell.cli"
 
-from .app import pprint_lines, process_xlsx, copy_global_values
+from .app import process_xlsx, copy_global_values
+from .template import pprint_lines
 from .oauth import get_drive_api
 from .contextmanagers import ensure_settings, ensure_project
 from .configure import tarbell_configure

--- a/tarbell/template.py
+++ b/tarbell/template.py
@@ -3,14 +3,13 @@
 All template code lives here, including Jinja filters and loaders.
 
 Filters are added to a blueprint, which can be registered on the Tarbell app.
-
-self.app.add_template_filter(format_date, 'format_date')
-self.app.add_template_filter(markdown, 'markdown')
-self.app.add_template_filter(slughifi, 'slugify')
-self.app.add_template_filter(pprint_lines, 'pprint_lines')
 """
+import codecs
+import datetime
+import dateutil
+import os
 from pprint import pformat
-from flask import Blueprint, render_template
+from flask import Blueprint, g, render_template
 from jinja2 import contextfunction, Markup
 from markdown import markdown as md
 
@@ -61,14 +60,20 @@ def render_file(path, absolute=False):
 def markdown(value):
     """
     Run text through markdown process
+
+    >>> markdown('*test*')
+    Markup(u'<p><em>test</em></p>')
     """
-    return Markup(md.markdown(value))
+    return Markup(md(value))
 
 
 @filters.app_template_filter('format_date')
 def format_date(value, format='%b. %d, %Y', convert_tz=None):
     """
     Format an Excel date.
+
+    >>> format_date(42419.82163)
+    'Feb. 19, 2016'
     """
     if isinstance(value, float) or isinstance(value, int):
         seconds = (value - 25569) * 86400.0

--- a/tarbell/template.py
+++ b/tarbell/template.py
@@ -159,3 +159,6 @@ def pprint_lines(value):
     )
     return Markup(formatted)
 
+# add slughifi
+filters.add_app_template_filter(slughifi)
+

--- a/tarbell/template.py
+++ b/tarbell/template.py
@@ -89,6 +89,14 @@ def read_file(path, absolute=False, encoding='utf-8'):
     """
     Read the file at `path`. If `absolute` is True, use absolute path,
     otherwise path is assumed to be relative to Tarbell template root dir.
+    
+    For example:
+
+    .. code-block:: html+jinja
+    
+        <div class="chapter">
+            {{ read_file('_chapters/one.txt')|linebreaks }}
+        </div>
     """
     site = g.current_site
     if not absolute:
@@ -103,7 +111,17 @@ def read_file(path, absolute=False, encoding='utf-8'):
 @filters.app_template_global('render_file')
 def render_file(path, absolute=False):
     """
-    Render a file with the current context
+    Like :py:func:`read_file`, except that the file is rendered as a Jinja template 
+    using the current context. If `absolute` is True, use absolute path, otherwise 
+    path is assumed to be relative to Tarbell template root dir.
+        
+    For example:
+
+    .. code-block:: html+jinja
+    
+        <div class="chapter">
+            {{ render_file('_chapters/one.txt') }}
+        </div>
     """
     site = g.current_site
     if not absolute:
@@ -126,10 +144,16 @@ def markdown(value):
 @filters.app_template_filter('format_date')
 def format_date(value, format='%b. %d, %Y', convert_tz=None):
     """
-    Format an Excel date.
+    Format an Excel date or date string, returning a formatted date.
+    To return a Python :py:class:`datetime.datetime` object, pass ``None``
+    as a ``format`` argument.
 
     >>> format_date(42419.82163)
     'Feb. 19, 2016'
+
+    .. code-block:: html+jinja
+
+        {{ row.date|format_date('%Y-%m-%d') }}
     """
     if isinstance(value, float) or isinstance(value, int):
         seconds = (value - 25569) * 86400.0

--- a/tarbell/template.py
+++ b/tarbell/template.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+All template code lives here, including Jinja filters and loaders.
+
+Filters are added to a blueprint, which can be registered on the Tarbell app.
+
+self.app.add_template_filter(format_date, 'format_date')
+self.app.add_template_filter(markdown, 'markdown')
+self.app.add_template_filter(slughifi, 'slugify')
+self.app.add_template_filter(pprint_lines, 'pprint_lines')
+"""
+from pprint import pformat
+from flask import Blueprint, render_template
+from jinja2 import contextfunction, Markup
+from markdown import markdown as md
+
+from .slughifi import slughifi
+
+
+filters = Blueprint('filters', __name__)
+
+
+def silent_none(value):
+    """
+    Return `None` values as empty strings
+    """
+    if value is None:
+        return ''
+    return value
+
+
+@filters.app_template_global('read_file')
+def read_file(path, absolute=False, encoding='utf-8'):
+    """
+    Read the file at `path`. If `absolute` is True, use absolute path,
+    otherwise path is assumed to be relative to Tarbell template root dir.
+    """
+    site = g.current_site
+    if not absolute:
+        path = os.path.join(site.path, path)
+
+    try:
+        return codecs.open(path, 'r', encoding).read()
+    except IOError:
+        return None
+
+
+@filters.app_template_global('render_file')
+def render_file(path, absolute=False):
+    """
+    Render a file with the current context
+    """
+    site = g.current_site
+    if not absolute:
+        path = os.path.join(site.path, path)
+
+    return render_template(path, **context)
+
+
+@filters.app_template_filter('markdown')
+def markdown(value):
+    """
+    Run text through markdown process
+    """
+    return Markup(md.markdown(value))
+
+
+@filters.app_template_filter('format_date')
+def format_date(value, format='%b. %d, %Y', convert_tz=None):
+    """
+    Format an Excel date.
+    """
+    if isinstance(value, float) or isinstance(value, int):
+        seconds = (value - 25569) * 86400.0
+        parsed = datetime.datetime.utcfromtimestamp(seconds)
+    else:
+        parsed = dateutil.parser.parse(value)
+    if convert_tz:
+        local_zone = dateutil.tz.gettz(convert_tz)
+        parsed = parsed.astimezone(tz=local_zone)
+
+    return parsed.strftime(format)
+
+
+@filters.app_template_filter('pprint_lines')
+def pprint_lines(value):
+    """
+    Pretty print lines
+    """
+    pformatted = pformat(value, width=1, indent=4)
+    formatted = "{0}\n {1}\n{2}".format(
+        pformatted[0],
+        pformatted[1:-1],
+        pformatted[-1]
+    )
+    return Markup(formatted)
+


### PR DESCRIPTION
Part of a larger effort to move functionality out of `tarbell.app`, this adds `tarbell.template` and puts all filters and functions there. All filters are registered on a blueprint (`tarbell.template.filters`) which gets added to `TarbellSite.app` in one step.

Will probably also move `TarbellFileSystemLoader` into this module, too.