### PR TITLE
Option to get date obj from format_date filter

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -248,7 +248,7 @@ def process_text(text):
         return u''
 
 
-def format_date(value, format='%b. %d, %Y', convert_tz=None):
+def format_date(value, format='%b. %d, %Y', convert_tz=None, return_date_obj=False):
     """
     Format an Excel date.
     """
@@ -261,7 +261,10 @@ def format_date(value, format='%b. %d, %Y', convert_tz=None):
         local_zone = dateutil.tz.gettz(convert_tz)
         parsed = parsed.astimezone(tz=local_zone)
 
-    return parsed.strftime(format)
+    if return_date_obj:
+        return parsed
+    else:
+        return parsed.strftime(format)
 
 
 class TarbellSite:


### PR DESCRIPTION
... rather than formatted string.  

I needed to compare a `datetime` from Google Sheet with a `datetime.datetime.today()` in template context, so quickest, handiest way was adding option to the useful builtin `format_date` filter.