### PR TITLE
Get date object from format_date filter

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -248,7 +248,7 @@ def process_text(text):
         return u''
 
 
-def format_date(value, format='%b. %d, %Y', convert_tz=None):
+def format_date(value, format='%b. %d, %Y', convert_tz=None, return_date_obj=False):
     """
     Format an Excel date.
     """
@@ -261,7 +261,10 @@ def format_date(value, format='%b. %d, %Y', convert_tz=None):
         local_zone = dateutil.tz.gettz(convert_tz)
         parsed = parsed.astimezone(tz=local_zone)
 
-    return parsed.strftime(format)
+    if return_date_obj:
+        return parsed
+    else:
+        return parsed.strftime(format)
 
 
 class TarbellSite:

--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -248,7 +248,7 @@ def process_text(text):
         return u''
 
 
-def format_date(value, format='%b. %d, %Y', convert_tz=None, return_date_obj=False):
+def format_date(value, format='%b. %d, %Y', convert_tz=None):
     """
     Format an Excel date.
     """
@@ -261,11 +261,10 @@ def format_date(value, format='%b. %d, %Y', convert_tz=None, return_date_obj=Fal
         local_zone = dateutil.tz.gettz(convert_tz)
         parsed = parsed.astimezone(tz=local_zone)
 
-    if return_date_obj:
-        return parsed
-    else:
+    if format:
         return parsed.strftime(format)
-
+    else:
+        return parsed
 
 class TarbellSite:
     def __init__(self, path, client_secrets_path=None, quiet=False):


### PR DESCRIPTION
 ... by allowing `None` as a string format argument(s). No need for adding a third argument (as well as having to define a date format that you're not going to use anyhow!).