### PR TITLE
Pass site reference to blueprint and project when mounting

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -247,7 +247,7 @@ class TarbellSite:
 
         if base:
             base.base_dir = base_dir
-            self.app.register_blueprint(base.blueprint)
+            self.app.register_blueprint(base.blueprint, site=self)
 
         return base
 
@@ -318,7 +318,7 @@ class TarbellSite:
 
         # load the project blueprint, if it exists
         if hasattr(project, 'blueprint') and isinstance(project.blueprint, Blueprint):
-            self.app.register_blueprint(project.blueprint)
+            self.app.register_blueprint(project.blueprint, site=self)
 
         return project, base
 


### PR DESCRIPTION
This partially answers the issues in #422 by passing a reference to the current site to blueprints in `TarbellSite._get_base` and `TarbellSite.load_project`. This allows a pattern like this:

```python
# tarbell_config.py

from flask import Blueprint
blueprint = Blueprint('project', __name__)

@blueprint.record
def setup(state):
    if 'site' in state.options:
        site = state.options['site']
        path = site.path
        
    # do things with site and path
```

Or more interesting, in a blueprint:
```python
# _blueprint/blueprint.py

from flask import Blueprint
blueprint = Blueprint('base', __name__)

@blueprint.record
def setup(state):
    if 'site' in state.options:
        site = state.options['site']

        # add a Flask extension, which then uses those settings
        from flask.ext.thumbnails import Thumbnail
        site.thumbnails = Thumbnail(state.app)
```
```python
# and then in tarbell_config.py

@blueprint.record
def setup(state):
    # configure Tarbell's Flask app from tarbell_config.py
    state.app.config.from_object(__name__)

# these settings get picked up automatically
# because of state.app.config.from_object(__name__)
MEDIA_FOLDER = "img"
MEDIA_THUMBNAIL_FOLDER = "img/thumbnails"
```

It might still be worth leaving #422 open, because maybe signals or hooks are a better, more explicit option. But this opens up a lot of possibilities without much code change.