### PR TITLE
TEMPLATE_TYPES is a list

### DIFF
--- a/tarbell/app.py
+++ b/tarbell/app.py
@@ -32,9 +32,9 @@ SPREADSHEET_CACHE_TTL = 4
 VALID_CELL_TYPES = range(1, 5)
 
 # pass template variables to files with these mimetypes
-TEMPLATE_TYPES = (
+TEMPLATE_TYPES = [
     "text/html",
-)
+]
 
 EXCLUDES = ['.git/*', '.git', '.gitignore', '.*', '*.pyc', '*.py', '_*']
 


### PR DESCRIPTION
Switches `tarbell.app.TEMPLATE_TYPES` back to a list (from a tuple) so blueprints can still do [this](https://github.com/ajam/tarbell-big-read-template/blob/master/blueprint.py#L36):

```python
from tarbell.app import TEMPLATE_TYPES

TEMPLATE_TYPES.append("text/css")
TEMPLATE_TYPES.append("application/javascript")
```

Closes #429.