### PR TITLE
Use one VERSION variable everywhere

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@ import os
 import sys
 
 from setuptools import setup, find_packages
-
+from tarbell import __VERSION__ as VERSION
 
 APP_NAME = 'tarbell'
-VERSION = '1.0.7'
 
 settings = dict()
 

--- a/tarbell/__init__.py
+++ b/tarbell/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = '1.0.5'
+__VERSION__ = '1.0.7'
 LONG_VERSION = __VERSION__.replace('b', '-beta')


### PR DESCRIPTION
Closes #447 

Imports `__VERSION__` into `setup.py` so version is defined once, and only once. (If this causes bugs down the road with imports, we can move the current `tarbell/__init__.py` to something like `tarbell/version.py`.