### PR TITLE
Dependency change flask@0.10.1 to flask@0.12.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ Tarbell makes use of familiar, flexible tools to take the magic (and frustration
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "Flask==0.10.1",
+        "Flask==0.12.3",
         "Frozen-Flask==0.11",
         "Jinja2==2.7.3",
         "Markdown==2.4.1",


### PR DESCRIPTION
bugs in outdated flask dependency:
 Improper Input Validation [High Severity][https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.10.1
  Denial of Service (DOS) [High Severity][https://snyk.io/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.10.1