### PR TITLE
fix dependency- high severity issue in pyyaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ Tarbell makes use of familiar, flexible tools to take the magic (and frustration
         "Jinja2==2.7.3",
         "Markdown==2.4.1",
         "MarkupSafe==0.23",
-        "PyYAML==3.11",
+        "PyYAML==4.1",
         "boto==2.48.0",
         "clint==0.4.1",
         "gnureadline>=6.3.3",


### PR DESCRIPTION
  Upgrade pyyaml@3.11 to pyyaml@4.1 to fix
  - Arbitrary Code Execution [High Severity] in pyyaml@3.11